### PR TITLE
Avoid out-of-range values in Resamplers

### DIFF
--- a/aimsalgo/src/aimsalgo/resampling/splineresampler_d.h
+++ b/aimsalgo/src/aimsalgo/resampling/splineresampler_d.h
@@ -228,7 +228,15 @@ SplineResampler< T >::doResampleChannel(
 
         }
 
-      carto::RawConverter<double, ChannelType>().convert(intensity, outValue);
+      // Clip the values to the output datatype: such out-of-range should be
+      // rare, but they can occur due to overshoot with spline order >= 2.
+      if(intensity < std::numeric_limits<ChannelType>::lowest())
+        intensity = std::numeric_limits<ChannelType>::lowest();
+      else if(intensity > std::numeric_limits<ChannelType>::max())
+        intensity = std::numeric_limits<ChannelType>::max();
+      else
+        carto::RawConverter<double, ChannelType>().convert(intensity,
+                                                           outValue);
 
     }
   else


### PR DESCRIPTION
Adding some checks to prevent invalid values due to out-of-range conversions (e.g. double -> uint16 generating values > 65000 due to negative interpolated values).

@denisri Do you think we should fix it like this, or maybe incorporate these checks in `RawConverter` itself?