### PR TITLE
Fixes attribute handling within pydicom Dataset

### DIFF
--- a/pyaims/python/soma/dicom/aggregator.py
+++ b/pyaims/python/soma/dicom/aggregator.py
@@ -68,7 +68,7 @@ class DicomAggregator( object ):
         positions_and_orientations = []
         for f in self._dicom_sources:
             try:
-                ds = dicom.read_file( f )
+                ds = dicom.read_file( f, stop_before_pixels=True )
             except Exception as e:
                 print(e)
                 continue
@@ -97,12 +97,8 @@ class DicomAggregator( object ):
                 serie_sop_uids[ serie_uid ] = []
 
             position_and_orientation=[]
-            if "ImagePositionPatient" in ds:
-                position_and_orientation.append(ds.ImagePositionPatient)
-            if "ImageOrientationPatient" in ds:
-                position_and_orientation.append(ds.ImageOrientationPatient)
-            if "FrameReferenceTime" in ds:
-                position_and_orientation.append(ds.FrameReferenceTime)
+            for tag in ("ImagePositionPatient","ImageOrientationPatient","FrameReferenceTime"):
+                position_and_orientation.append(ds.get(tag) if tag in ds else None)
             
             sop_uid = ds.SOPInstanceUID
             if not sop_uid in serie_sop_uids[ serie_uid ] and \
@@ -110,5 +106,5 @@ class DicomAggregator( object ):
                 serie_sop_uids[ serie_uid ].append( sop_uid )
                 self._aggregate_sources[ serie_uid ].append( f )
                 
-#                if position_and_orientation is not None:
-#                    positions_and_orientations.append( position_and_orientation )
+                if all(x is not None for x in position_and_orientation):
+                    positions_and_orientations.append( position_and_orientation )

--- a/pyaims/python/soma/dicom/aggregator.py
+++ b/pyaims/python/soma/dicom/aggregator.py
@@ -96,13 +96,13 @@ class DicomAggregator( object ):
                 self._aggregate_sources[ serie_uid ] = []
                 serie_sop_uids[ serie_uid ] = []
 
-            try:
-                position_and_orientation = ( ds.ImagePositionPatient,
-                                             ds.ImageOrientationPatient,
-                                             ds.FrameReferenceTime )
-            except Exception as e:
-                print(e)
-                position_and_orientation = None
+            position_and_orientation=[]
+            if "ImagePositionPatient" in ds:
+                position_and_orientation.append(ds.ImagePositionPatient)
+            if "ImageOrientationPatient" in ds:
+                position_and_orientation.append(ds.ImageOrientationPatient)
+            if "FrameReferenceTime" in ds:
+                position_and_orientation.append(ds.FrameReferenceTime)
             
             sop_uid = ds.SOPInstanceUID
             if not sop_uid in serie_sop_uids[ serie_uid ] and \


### PR DESCRIPTION
This adds handling for instances where a specified attribute is not found within the pydicom Dataset. For instance, if DICOM tag *FrameReferenceTime* is not found within the header the current behaviour will display `Dataset does not have attribute 'FrameReferenceTime'`. This PR fixes this issue by first checking if the attribute is found within the pydicom Dataset.