### PR TITLE
Added CMake variables to allow OpenGL linking customization

### DIFF
--- a/aimsgui/src/CMakeLists.txt
+++ b/aimsgui/src/CMakeLists.txt
@@ -19,6 +19,8 @@ add_subdirectory( aimscifti )
 #------------------------------------------------------------------------------
 # Build targets for commands by looking into "Aims*" directories
 #------------------------------------------------------------------------------
+link_directories(${OPENGL_LIBRARY_DIRECTORIES})
+
 foreach( _command AimsAttributedViewer AimsLabelSelector )
   if( IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_command}" )
     file( GLOB _pro "${CMAKE_CURRENT_SOURCE_DIR}/${_command}/*.pro" )
@@ -31,7 +33,7 @@ foreach( _command AimsAttributedViewer AimsLabelSelector )
     endforeach()
 
     BRAINVISA_ADD_EXECUTABLE( ${_target} ${_guiExecutable} ${_sources} )
-    target_link_libraries( ${_target} aimsgui )
+    target_link_libraries( ${_target} aimsgui ${OPENGL_LIBRARIES} )
 
     if( APPLE )
       add_custom_command( TARGET ${_target} POST_BUILD

--- a/aimsgui/src/CMakeLists.txt
+++ b/aimsgui/src/CMakeLists.txt
@@ -19,7 +19,7 @@ add_subdirectory( aimscifti )
 #------------------------------------------------------------------------------
 # Build targets for commands by looking into "Aims*" directories
 #------------------------------------------------------------------------------
-link_directories(${OPENGL_LIBRARY_DIRECTORIES})
+link_directories(${OPENGL_FIX_LIBRARY_DIRECTORIES})
 
 foreach( _command AimsAttributedViewer AimsLabelSelector )
   if( IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_command}" )
@@ -33,7 +33,7 @@ foreach( _command AimsAttributedViewer AimsLabelSelector )
     endforeach()
 
     BRAINVISA_ADD_EXECUTABLE( ${_target} ${_guiExecutable} ${_sources} )
-    target_link_libraries( ${_target} aimsgui ${OPENGL_LIBRARIES} )
+    target_link_libraries( ${_target} aimsgui ${OPENGL_FIX_LIBRARIES} )
 
     if( APPLE )
       add_custom_command( TARGET ${_target} POST_BUILD

--- a/pyaims/src/sip/genericobject.sip
+++ b/pyaims/src/sip/genericobject.sip
@@ -103,7 +103,7 @@ namespace carto
     }
 %End
 
-  Py_hash_t __hash__() const;
+  long __hash__() const;
 %MethodCode
   sipRes = static_cast<long>( reinterpret_cast<unsigned long long>(sipCpp) );
 %End

--- a/pyaims/src/sip/rcobject.sip
+++ b/pyaims/src/sip/rcobject.sip
@@ -250,7 +250,7 @@ if( sipIsPyOwned( (sipWrapper *) a0Wrapper )
   }
 %End
 
-  Py_hash_t __hash__() const;
+  long __hash__() const;
 %MethodCode
   sipRes = static_cast<long>( reinterpret_cast<unsigned long long>(sipCpp) );
 %End

--- a/pyaims/src/sip/rcptr.tpl
+++ b/pyaims/src/sip/rcptr.tpl
@@ -159,7 +159,7 @@ public:
   bool operator == ( const rc_ptr_%Template1typecode% & x ) const;
   bool operator != ( const rc_ptr_%Template1typecode% & x ) const;
   bool operator < ( const rc_ptr_%Template1typecode% & x ) const;
-  Py_hash_t __hash__() const;
+  long __hash__() const;
 %MethodCode
   sipRes = 
 #if defined( _WIN64 )

--- a/pyaims/src/sip/sharedptr.tpl
+++ b/pyaims/src/sip/sharedptr.tpl
@@ -166,7 +166,7 @@ public:
   bool operator < ( const rc_ptr_%Template1typecode% & x ) const;
   bool operator < ( const weak_shared_ptr_%Template1typecode% & x ) const;
   bool operator < ( const weak_ptr_%Template1typecode% & x ) const;
-  Py_hash_t __hash__() const;
+  long __hash__() const;
 %MethodCode
   sipRes = 
 #if defined( _WIN64 )
@@ -298,7 +298,7 @@ public:
   bool operator < ( const rc_ptr_%Template1typecode% & x ) const;
   bool operator < ( const weak_shared_ptr_%Template1typecode% & x ) const;
   bool operator < ( const weak_ptr_%Template1typecode% & x ) const;
-  Py_hash_t __hash__() const;
+  long __hash__() const;
 %MethodCode
   sipRes = 
 #if defined( _WIN64 )


### PR DESCRIPTION
To allow compilation in a build environment set up using Conda, I added two optional CMake variables that must be used when compiling OpenGL code:

- `OPENGL_LIBRARY_DIRECTORIES` that contains a list of directory to add to the linker (with the `-L` option) when OpenGL is used.
- `OPENGL_LIBRARIES` containing a list of libraries to add to the linker for OpenGL.

The content of these variables will be set only when necessary. For the moment they are defined in `bv_maker.cfg`.