### PR TITLE
Fix orientation of mesh normals after indirect transformations

### DIFF
--- a/aimsalgo/src/aimsalgo/registration/ffd.cc
+++ b/aimsalgo/src/aimsalgo/registration/ffd.cc
@@ -520,6 +520,20 @@ void FfdTransformation::estimateLocalDisplacement( const Point3df & VoxelSize)
 }
 #endif
 
+bool FfdTransformation::isDirect() const
+{
+  // FIXME: in theory a FFD (free-form deformation) can be direct or indirect,
+  // or even both in pathological cases (i.e. locally direct is some places,
+  // locally indirect in others). However, in practice we normally use FFDs to
+  // express the residual deformation after an affine transformation, so in
+  // these cases the FFD is always direct. Moreover, testing if the
+  // transformation is direct or indirect would be ambiguous, so let's assume
+  // that all FFDs are direct (the only side effect that I see so far is that
+  // mesh normals may fail to be reversed in the case of an indirect FFD).
+  // -- Yann Leprince 2023-07-28
+  return true;
+}
+
 void FfdTransformation::printControlPointsGrid() const
 {
   for( int z = 0; z < _ctrlPointDelta->getSizeZ(); ++z ) {

--- a/aimsalgo/src/aimsalgo/registration/ffd.h
+++ b/aimsalgo/src/aimsalgo/registration/ffd.h
@@ -64,6 +64,8 @@ namespace aims {
     /// Always false, because testing for identity is expensive
     bool isIdentity() const CARTO_OVERRIDE { return false; }
 
+    bool isDirect() const override;
+
     //--- Control Knots ------------------------------------------------------
     Point3df     getCtrlKnot( int nx, int ny, int nz ) const;
     void         updateCtrlKnot( int nx, int ny, int nz, const Point3df & newCtrlKnot );

--- a/aimsalgo/src/aimsalgo/transform/transform_objects_d.h
+++ b/aimsalgo/src/aimsalgo/transform/transform_objects_d.h
@@ -34,6 +34,7 @@
 #include <aims/transform/transform_objects.h>
 
 #include <aims/mesh/surface.h>
+#include <aims/mesh/surfacemanip.h>
 
 using namespace std;
 using namespace carto;
@@ -58,7 +59,14 @@ void transformMesh( AimsTimeSurface<D, Void> & mesh,
     }
   }
 
-  mesh.updateNormals();
+  if(!direct_transformation.isDirect()) {
+    SurfaceManip::invertSurfacePolygons(mesh);
+  }
+
+  if(!mesh.normal().empty()) {
+    // Old normals are not valid anymore, recalculate them if they were present
+    mesh.updateNormals();
+  }
 }
 
 } // namespace aims

--- a/aimsdata/src/aimsdata/transformation/transformation_chain.cc
+++ b/aimsdata/src/aimsdata/transformation/transformation_chain.cc
@@ -133,6 +133,21 @@ aims::TransformationChain3d::getInverse() const
   return ret;
 }
 
+bool aims::TransformationChain3d::isDirect() const
+{
+  bool result = true;
+  for(auto it = _transformations.begin(),
+        itend = _transformations.end() ;
+      it != itend ;
+      ++it)
+  {
+    if(!(*it)->isDirect()) {
+      result = !result;
+    }
+  }
+  return result;
+}
+
 Point3dd aims::TransformationChain3d::
 transformPoint3dd( const Point3dd& point ) const
 {

--- a/aimsdata/src/aimsdata/transformation/transformation_chain.h
+++ b/aimsdata/src/aimsdata/transformation/transformation_chain.h
@@ -89,6 +89,7 @@ public:
   bool isIdentity() const CARTO_OVERRIDE;
   bool invertible() const CARTO_OVERRIDE;
   std::unique_ptr<soma::Transformation> getInverse() const CARTO_OVERRIDE;
+  bool isDirect() const override;
 
   /** Compute a simpler transformation that is equivalent to the chain.
 


### PR DESCRIPTION
Fixes: https://github.com/brainvisa/aims-free/issues/103

Beware that this PR goes along with https://github.com/brainvisa/soma-io/pull/27, both must be merged simultenaously or builds will break.